### PR TITLE
Fix bug in parameter passing to jq for complex queries

### DIFF
--- a/start
+++ b/start
@@ -38,7 +38,7 @@ j2y() {
 }
 
 yq() {
-  local jq_response="$(y2j | jq "$@")"
+  local jq_response=$(y2j | jq "$*")
   if is_json "$jq_response"; then
     echo "$jq_response" | j2y
   else
@@ -67,9 +67,9 @@ read_value() {
   shift
 
   if is_json "$input"; then
-    echo "$input" | jq "$@"
+    echo "$input" | jq "$*"
   else
-    echo "$input" | yq "$@"
+    echo "$input" | yq "$*"
   fi
 }
 

--- a/start_test.bats
+++ b/start_test.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 in_docker() {
-  docker run -i --rm -v `pwd`:/jyparser:ro jlordiales/jyparser $@
+  docker run -i --rm -v "`pwd`/start":/bin/start  -v "`pwd`":/jyparser:ro jlordiales/jyparser $@
 }
 
 @test "operation different than set or get shows usage instructions" {
@@ -66,4 +66,14 @@ in_docker() {
 @test "set can update YAML coming from file" {
   result=$(in_docker test.yml set .menu.id 1 | in_docker get .menu.id)
   [ "$result" = "1" ]
+}
+
+@test "get can perform complex jq queries with YAML" {
+  run in_docker test.yml get ".menu | to_entries | .[] | [\"command\", .key, \"\(.value)\"] | @sh"
+  [ $(expr "${lines[0]}" : ".*command.*") -ne 0 ]
+}
+
+@test "get can perform complex jq queries with JSON" {
+  run in_docker test.json get ".menu | to_entries | .[] | [\"command\", .key, \"\(.value)\"] | @sh"
+  [ $(expr "${lines[0]}" : ".*command.*") -ne 0 ]
 }


### PR DESCRIPTION
The following test fails in the pre-merge code:
`@test "get can perform complex jq queries with YAML" {`
`  run in_docker test.yml get ".menu | to_entries | .[] | [\"command\", .key, \"\(.value)\"] | @sh"`
`  [ $(expr "${lines[0]}" : ".*command.*") -ne 0 ]`
`}`

Suggested fixes:

1. Fix bug in parameter passing to jq creating the error: 
jq: error: syntax error, unexpected INVALID_CHARACTER, expecting  (Unix shell quoting issues?). 

The essence of the fix is that you need to pass "$*" instead of "$@" to the jq command.

2. Also fix start_test.bats so that it allows for spaces in 'pwd' (quoting around ``"`pwd`"``) and adds unit tests to prove the advanced jq queries will work.

3. As a bonus, in start_test.bats, added the following volume mapping in in_docker():
``-v "`pwd`/start":/bin/start``

The above allows you to edit the start script locally and test the updated script without rebuilding the Docker image.