### PR TITLE
Allow command line options in jq

### DIFF
--- a/start
+++ b/start
@@ -38,7 +38,7 @@ j2y() {
 }
 
 yq() {
-  local jq_response=$(y2j | jq "$*")
+  local jq_response=$(y2j | jq "$@")
   if is_json "$jq_response"; then
     echo "$jq_response" | j2y
   else
@@ -67,9 +67,9 @@ read_value() {
   shift
 
   if is_json "$input"; then
-    echo "$input" | jq "$*"
+    echo "$input" | jq "$@"
   else
-    echo "$input" | yq "$*"
+    echo "$input" | yq "$@"
   fi
 }
 

--- a/start_test.bats
+++ b/start_test.bats
@@ -77,3 +77,8 @@ in_docker() {
   run in_docker test.json get ".menu | to_entries | .[] | [\"command\", .key, \"\(.value)\"] | @sh"
   [ $(expr "${lines[0]}" : ".*command.*") -ne 0 ]
 }
+
+@test "get can use jq built-in parameters (like -r for raw output)" {
+  result=$(cat test.yml | in_docker get -r .menu.popup.menuitem[0].value)
+  [ "$result" = "New" ]
+}

--- a/start_test.bats
+++ b/start_test.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 in_docker() {
-  docker run -i --rm -v "`pwd`/start":/bin/start  -v "`pwd`":/jyparser:ro jlordiales/jyparser $@
+  docker run -i --rm -v "`pwd`/start":/bin/start  -v "`pwd`":/jyparser:ro jlordiales/jyparser "$@"
 }
 
 @test "operation different than set or get shows usage instructions" {
@@ -78,7 +78,12 @@ in_docker() {
   [ $(expr "${lines[0]}" : ".*command.*") -ne 0 ]
 }
 
-@test "get can use jq built-in parameters (like -r for raw output)" {
+@test "get can use jq built-in parameters (like -r for raw output) with JSON" {
+  result=$(cat test.json | in_docker get -r .menu.popup.menuitem[0].value)
+  [ "$result" = "New" ]
+}
+
+@test "get can use jq built-in parameters (like -r for raw output) with YAML" {
   result=$(cat test.yml | in_docker get -r .menu.popup.menuitem[0].value)
   [ "$result" = "New" ]
 }


### PR DESCRIPTION
 @jonathandandries, unfortunately your PR broke the passing of command line arguments to jq (like -r for raw output). I added some tests for it now (which are failing on master).

Just thought I would give you a heads up. The test cases you added are still passing so I assume I didn't break your use case but you might want to double check